### PR TITLE
Prevent element leaks

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -66,6 +66,7 @@ default[:metroextractor][:vex][:url]                  = "https://github.com/mapz
 
 default[:metroextractor][:osmconvert][:timeout]       = 172_800
 default[:metroextractor][:osmconvert][:jobs]          = node[:cpu][:total]
+default[:metroextractor][:osmconvert][:hash_memory]   = 1500
 
 # shapes: note that the number of jobs below reflects close to the limit of what the
 #   local postgres instance can handle in terms of max connections. Not recommended

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -66,6 +66,7 @@ default[:metroextractor][:vex][:url]                  = "https://github.com/mapz
 
 default[:metroextractor][:osmconvert][:timeout]       = 172_800
 default[:metroextractor][:osmconvert][:jobs]          = node[:cpu][:total]
+# hash_memory is in megs
 default[:metroextractor][:osmconvert][:hash_memory]   = 1500
 
 # shapes: note that the number of jobs below reflects close to the limit of what the

--- a/templates/default/extracts_osmconvert.sh.erb
+++ b/templates/default/extracts_osmconvert.sh.erb
@@ -3,6 +3,17 @@
 <% data = JSON.parse(json) -%>
 <% data['regions'].each do |_, v| -%>
   <% v['cities'].each do |city, val| -%>
-    osmconvert planet.o5m --out-pbf -b=<%= val['bbox']['left'] %>,<%= val['bbox']['bottom'] %>,<%= val['bbox']['right'] %>,<%= val['bbox']['top'] %> --drop-broken-refs -o=ex/<%= city %>.osm.pbf && osmconvert ex/<%= city %>.osm.pbf --out-osm -o=ex/<%= city %>.osm && pbzip2 -f ex/<%= city %>.osm
+    osmconvert \
+      planet.o5m \
+      --out-pbf \
+      -b=<%= val['bbox']['left'] %>,<%= val['bbox']['bottom'] %>,<%= val['bbox']['right'] %>,<%= val['bbox']['top'] %> \
+      --hash-memory=<%= node[:metroextractor][:osmconvert][:hash_memory] %> \
+      --drop-broken-refs \
+      -o=ex/<%= city %>.osm.pbf && \
+    osmconvert \
+      ex/<%= city %>.osm.pbf \
+      --out-osm \
+      -o=ex/<%= city %>.osm && \
+    pbzip2 -f ex/<%= city %>.osm
   <% end %>
 <% end %>


### PR DESCRIPTION
This should eliminate the error where a user noticed Danish `way`s in the Boston metro extract.

@heffergm could you review please?